### PR TITLE
Enforce no spaces around jsx attribute expressions.

### DIFF
--- a/react/rules/jsx.js
+++ b/react/rules/jsx.js
@@ -3,7 +3,7 @@ module.exports = {
         "react/jsx-boolean-value": "error",
         "react/jsx-closing-bracket-location": "error",
         "react/jsx-closing-tag-location": "error",
-        "react/jsx-curly-spacing": ["error", "always"],
+        "react/jsx-curly-spacing": ["error", "never"],
         "react/jsx-equals-spacing": "error",
         "react/jsx-filename-extension": "error",
         "react/jsx-first-prop-new-line": ["error", "multiline"],


### PR DESCRIPTION
Previously this was set to enforce having these spaces, e.g.

```jsx
<Foo bar={ baz } />
```

However, by popular request amongst the users of this library this PR changes this to

```jsx
<Foo bar={baz} />
```

Fixes #2.